### PR TITLE
spelling: clear text + clear-text = cleartext

### DIFF
--- a/doc/mpop.1
+++ b/doc/mpop.1
@@ -245,7 +245,7 @@ joe.smith with your user name.
 to specify a command to decrypt that file, e.g. using GnuPG. See EXAMPLES.
 .br
 3. Store the password in the configuration file using the \fBpassword\fP command.
-(Usually it is not considered a good idea to store passwords in plain text files.
+(Usually it is not considered a good idea to store passwords in cleartext files.
 If you do it anyway, you must make sure that the file can only be read by yourself.)
 .br
 4. Store the password in ~/.netrc. This method is probably obsolete.
@@ -263,7 +263,7 @@ some reason, only methods that avoid sending cleartext passwords are
 considered.
 .br
 The following user / password methods are supported: \fIuser\fP (a simple plain
-text method supported by all servers), \fIplain\fP (another simple plain text
+text method supported by all servers), \fIplain\fP (another simple cleartext
 method, supported by almost all servers),
 \fIscram\-sha\-1\fP (a method that avoids cleartext passwords),
 \fIapop\fP (an obsolete method that avoids cleartext passwords, but is not
@@ -297,12 +297,12 @@ Set the user name for authentication. An empty argument unsets the user name.
 .IP "password \fIsecret\fP"
 Set the password for authentication. An empty argument unsets the password.
 Consider using the \fBpasswordeval\fP command or a key ring instead of this
-command, to avoid storing plain text passwords in the configuration file.
+command, to avoid storing cleartext passwords in the configuration file.
 .IP "passwordeval [\fIeval\fP]"
 Set the password for authentication to the output (stdout) of the command
 \fIeval\fP.
 This can be used e.g. to decrypt password files on the fly or to query key
-rings, and thus to avoid storing plain text passwords.
+rings, and thus to avoid storing cleartext passwords.
 .IP "ntlmdomain [\fIdomain\fP]"
 Set a domain for the \fBntlm\fP authentication method. This is obsolete.
 .IP "tls [(\fIon\fP|\fIoff\fP)]"
@@ -673,7 +673,7 @@ passwordeval gpg2 \-\-no\-tty \-q \-d ~/.mpop\-password.gpg
 .br
 # Password method 3: Store the password directly in this file. Usually it is not
 .br
-# a good idea to store passwords in plain text files. If you do it anyway, at
+# a good idea to store passwords in cleartext files. If you do it anyway, at
 .br
 # least make sure that this file can only be read by yourself.
 .br

--- a/doc/mpop.1
+++ b/doc/mpop.1
@@ -259,20 +259,20 @@ Historically, sophisticated methods were developed to protect passwords from
 being sent unencrypted to the server, but nowadays everybody needs TLS anyway,
 so the simple methods suffice since the whole session is protected. A suitable
 authentication method is chosen automatically, and when TLS is disabled for
-some reason, only methods that avoid sending clear text passwords are
+some reason, only methods that avoid sending cleartext passwords are
 considered.
 .br
 The following user / password methods are supported: \fIuser\fP (a simple plain
 text method supported by all servers), \fIplain\fP (another simple plain text
 method, supported by almost all servers),
-\fIscram\-sha\-1\fP (a method that avoids clear-text passwords),
-\fIapop\fP (an obsolete method that avoids clear-text passwords, but is not
+\fIscram\-sha\-1\fP (a method that avoids cleartext passwords),
+\fIapop\fP (an obsolete method that avoids cleartext passwords, but is not
 considered secure anymore),
-\fIcram\-md5\fP (an obsolete method that avoids clear-text passwords, but is not
+\fIcram\-md5\fP (an obsolete method that avoids cleartext passwords, but is not
 considered secure anymore),
 \fIdigest\-md5\fP (an overcomplicated
-obsolete method that avoids clear-text passwords, but is not considered secure
-anymore), \fIlogin\fP (a non-standard clear-text method similar to but worse
+obsolete method that avoids cleartext passwords, but is not considered secure
+anymore), \fIlogin\fP (a non-standard cleartext method similar to but worse
 than the plain method), \fIntlm\fP (an obscure non-standard method that is now
 considered broken; it sometimes requires a special domain parameter passed via
 \fBntlmdomain\fP).

--- a/doc/mpop.texi
+++ b/doc/mpop.texi
@@ -210,14 +210,14 @@ Set the user name for authentication. An empty argument unsets the user name.
 @cmindex password
 Set the password for authentication. An empty argument unsets the password.
 Consider using the @samp{passwordeval} command or a key ring instead of this
-command, to avoid storing plain text passwords in the configuration file.
+command, to avoid storing cleartext passwords in the configuration file.
 @anchor{passwordeval}
 @item passwordeval [@var{eval}]
 @cmindex passwordeval
 Set the password for authentication to the output (stdout) of the command
 @var{eval}.
 This can be used e.g. to decrypt password files on the fly or to query key
-rings, and thus to avoid storing plain text passwords.
+rings, and thus to avoid storing cleartext passwords.
 @anchor{ntlmdomain}
 @item ntlmdomain [@var{ntlmdomain}]
 @cmindex ntlmdomain
@@ -811,7 +811,7 @@ joe.smith with your user name.
 @item Store the password in an encrypted files, and use @ref{passwordeval}
 to specify a command to decrypt that file, e.g. using GnuPG. @xref{Examples}.
 @item Store the password in the configuration file using the @ref{password} command.
-(Usually it is not considered a good idea to store passwords in plain text files.
+(Usually it is not considered a good idea to store passwords in cleartext files.
 If you do it anyway, you must make sure that the file can only be read by yourself.)
 @item Store the password in @file{~/.netrc}. This method is probably obsolete.
 @item Type the password into the terminal when it is required.
@@ -829,9 +829,9 @@ sending cleartext passwords are considered.
 The following user / password methods are supported:
 @itemize
 @item @samp{USER}@*
-A simple plain text method supported by all servers.
+A simple cleartext method supported by all servers.
 @item @samp{PLAIN}@*
-Another simple plain text method supported by almost all servers.
+Another simple cleartext method supported by almost all servers.
 @item @samp{SCRAM-SHA-1}@*
 A method that avoids cleartext passwords.
 @item @samp{APOP}@*
@@ -1125,7 +1125,7 @@ user joe.smith
 passwordeval gpg2 --no-tty -q -d ~/.mpop-password.gpg
 
 # Password method 3: Store the password directly in this file. Usually it is not
-# a good idea to store passwords in plain text files. If you do it anyway, at
+# a good idea to store passwords in cleartext files. If you do it anyway, at
 # least make sure that this file can only be read by yourself.
 #password secret123
 

--- a/doc/mpop.texi
+++ b/doc/mpop.texi
@@ -824,7 +824,7 @@ being sent unencrypted to the server, but nowadays everybody needs
 @ref{Transport Layer Security} anyway, so the simple methods suffice since the
 whole session is protected. A suitable authentication method is chosen
 automatically, and when TLS is disabled for some reason, only methods that avoid
-sending clear text passwords are considered.
+sending cleartext passwords are considered.
 
 The following user / password methods are supported:
 @itemize
@@ -833,18 +833,18 @@ A simple plain text method supported by all servers.
 @item @samp{PLAIN}@*
 Another simple plain text method supported by almost all servers.
 @item @samp{SCRAM-SHA-1}@*
-A method that avoids clear-text passwords.
+A method that avoids cleartext passwords.
 @item @samp{APOP}@*
-An obsolete method that avoids clear-text passwords, but is not considered
+An obsolete method that avoids cleartext passwords, but is not considered
 secure anymore.
 @item @samp{CRAM-MD5}@*
-An obsolete method that avoids clear-text passwords, but is not considered
+An obsolete method that avoids cleartext passwords, but is not considered
 secure anymore.
 @item @samp{DIGEST-MD5}@*
-An overcomplicated obsolete method that avoids clear-text passwords, but is not
+An overcomplicated obsolete method that avoids cleartext passwords, but is not
 considered secure anymore.
 @item @samp{LOGIN}@*
-A non-standard clear-text method similar to (but worse than) PLAIN.
+A non-standard cleartext method similar to (but worse than) PLAIN.
 @item @samp{NTLM}@*
 An obscure non-standard method that is now considered broken. It sometimes requires
 a special domain parameter passed via @ref{ntlmdomain}. Do not use it.

--- a/doc/mpoprc.example
+++ b/doc/mpoprc.example
@@ -63,7 +63,7 @@ user joe.smith
 passwordeval gpg2 --no-tty -q -d ~/.mpop-password.gpg
 
 # Password method 3: Store the password directly in this file. Usually it is not
-# a good idea to store passwords in plain text files. If you do it anyway, at
+# a good idea to store passwords in cleartext files. If you do it anyway, at
 # least make sure that this file can only be read by yourself.
 #password secret123
 

--- a/src/pop3.h
+++ b/src/pop3.h
@@ -346,7 +346,7 @@ int pop3_server_supports_authmech(pop3_session_t *session, const char *mech);
  * to find out which authentication mechanisms are available.
  * The special value "" for 'auth_mech' causes the function to choose the best
  * authentication method supported by the server, unless TLS is inactive and the
- * method sends plain text passwords. In this case, the function fails with
+ * method sends cleartext passwords. In this case, the function fails with
  * POP3_EINSECURE.
  * The hostname is the name of the POP3 server. It may be needed for
  * authentication.


### PR DESCRIPTION
The correct spelling is "cleartext", let's change "clear text" and "clear-text" to that.